### PR TITLE
update readme to install ocaml 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,7 @@ With opam version >= 2.1:
 
 ```bash
 opam update
-opam switch create 5.0.0~alpha0 --repo=default,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
-opam install . --deps-only
-eval $(opam env)
-```
-
-with opam version < 2.1:
-
-```bash
-opam update
-opam switch create 5.0.0~alpha0 --repo=default,beta=git+https://github.com/ocaml/ocaml-beta-repository.git,alpha=git+https://github.com/kit-ty-kate/opam-alpha-repository.git
+opam switch create 5.1.0
 opam install . --deps-only
 eval $(opam env)
 ```


### PR DESCRIPTION
We're assuming opam version is >= 2.1, let me know if we need other instructions for opam version < 2.1?  

The rest of the tutorial seems to run fine with OCaml 5.1.0, except that running the `ocaml` toplevel results in an error with `Topdirs` not being found: 
``` 
OCaml version 5.1.0
Enter #help;; for help.

File "/home/kody/.ocamlinit", line 3, characters 6-27:
3 |   try Topdirs.dir_directory (Sys.getenv "OCAML_TOPLEVEL_PATH")
          ^^^^^^^^^^^^^^^^^^^^^
Error: Unbound module Topdirs
```